### PR TITLE
feat: Create data scraper for TEDTalks page.

### DIFF
--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -5,27 +5,20 @@ References:
 """
 
 from bs4 import BeautifulSoup
+import json
 import requests
 import os
 import re
+from urllib import request
 
 
-TEST_URL = "https://www.ted.com/talks/abdallah_ewis_the_forgotten_queen_of_egypt"
+TEST_URL = "https://www.ted.com/talks/ashley_whillans_3_rules_for_better_work_life_balance"
 
 # Storage locations
 DATA_STORAGE_ROOT = os.path.join(os.getcwd(), "scraper", "data")
 AUDIO_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "audio")
 TRANSCRIPT_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "transcript")
-
-# Scraper constants
-START_OF_TRANSCRIPT = "<!-- Transcript text -->"
-END_OF_TRANSCRIPT = "<!-- /Transcript text -->"
-# Allow "." to match newlines using re.DOTALL
-TRANSCRIPT_REGEX_PATTERN = re.compile(f"{START_OF_TRANSCRIPT}(.*?){END_OF_TRANSCRIPT}", re.DOTALL)
-
-TRANSCRIPT_TEXT_PARAGRAPH_TAG = "p"
-TRANSCRIPT_TEXT_PARAGRAPH_PATTERN = re.compile(f"<{TRANSCRIPT_TEXT_PARAGRAPH_TAG}>(.*?)"
-                                               f"</{TRANSCRIPT_TEXT_PARAGRAPH_TAG}>", re.DOTALL)
+PLACEHOLDER_FILE_NAME = "placeholder"
 
 
 def get_page_data_from_url(url):
@@ -40,24 +33,92 @@ def get_page_data_from_url(url):
 
     response = requests.get(url)
     if not response.ok:
-        print(f"Error encountered while accessing url: <{url}>")
-        return
+        print(f"No transcript exists: <{url}>")
+        return None
 
     return response.text
 
 
-def parse_page_data_from_text(page_text):
+# Audio constants
+# Notice that the opening and closing parentheses are escaped
+START_OF_METADATA = '<script data-spec="q">q\("talkPage.init",'
+END_OF_METADATA = '\)</script>'
+# Allow "." to match newlines using re.DOTALL
+METADATA_REGEX_PATTERN = re.compile(f"{START_OF_METADATA}(.*?){END_OF_METADATA}", re.DOTALL)
+METADATA_PATH_TO_AUDIO = ["__INITIAL_DATA__", "talks", 0, "downloads", "audioDownload"]
+AUDIO_FILE_EXTENSION = ".mp3"
+
+
+def parse_audio_from_page_text(page_text):
     """
-    Obtains the audio and transcript of a page, given its page text.
+    Obtains the audio data of a page, given its page text.
+    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks)
+
+    Workflow:
+    - Isolate and extract the audio download link from the page text using tag delimiters
+    - Call a download request to the audio download link to obtain the audio
+
+    :param page_text: The raw page text from the website, as parsed by the requests module.
+    :return: No return value, but will save the audio file to the path in AUDIO_DATA_STORAGE.
+    """
+    if not page_text:
+        print("No page text was passed to audio parser.")
+        return
+
+    raw_metadata = METADATA_REGEX_PATTERN.search(page_text)
+    if not raw_metadata:
+        print("No metadata object was found.")
+        return
+
+    json_metadata = json.loads(raw_metadata.group(1))
+
+    # Locate the audio download link by traversing down the JSON object
+    audio_metadata_url = json_metadata
+    for key in METADATA_PATH_TO_AUDIO:
+        try:
+            # Note: This deliberately does not distinguish between accessing between:
+            #           - a list, using an integer (e.g. 0)
+            #           - a dict, using a key.
+            # This is because the metadata object combines both nested lists and nested dicts.
+            audio_metadata_url = audio_metadata_url[key]
+        except (KeyError, IndexError):
+            print("The specified path to the audio download does not exist.")
+            return
+
+    if not audio_metadata_url:
+        print("No audio download link exists.")
+        return
+
+    audio_file_saved_location = os.path.join(AUDIO_DATA_STORAGE, PLACEHOLDER_FILE_NAME + AUDIO_FILE_EXTENSION)
+    _, _ = request.urlretrieve(audio_metadata_url, filename=audio_file_saved_location)
+    print("Audio file saved.")
+
+
+# Transcript constants
+START_OF_TRANSCRIPT = "<!-- Transcript text -->"
+END_OF_TRANSCRIPT = "<!-- /Transcript text -->"
+# Allow "." to match newlines using re.DOTALL
+TRANSCRIPT_REGEX_PATTERN = re.compile(f"{START_OF_TRANSCRIPT}(.*?){END_OF_TRANSCRIPT}", re.DOTALL)
+TRANSCRIPT_TEXT_PARAGRAPH_TAG = "p"
+TRANSCRIPT_FILE_EXTENSION = ".txt"
+
+
+def parse_transcript_from_page_text(page_text):
+    """
+    Obtains the speech transcript of a page, given its page text.
     Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks)
 
     Workflow:
     - Isolate and extract the transcript from the page text using the front and back comment delimiters
     - Use BeautifulSoup to tidy up the transcript by removing unnecessary HTML tags
 
-    :param page_text:
-    :return:
+    :param page_text: The raw page text from the website, as parsed by the requests module.
+    :return: No return value, but will save the transcript to the path in TRANSCRIPT_DATA_STORAGE
     """
+    if not page_text:
+        print("No page text was passed to transcript parser.")
+        return
+
     raw_transcript = TRANSCRIPT_REGEX_PATTERN.search(page_text)
     if not raw_transcript:
         print("No transcript was found.")
@@ -82,12 +143,19 @@ def parse_page_data_from_text(page_text):
 
         transcript.append(paragraph)
 
-    return " ".join(transcript)
+    transcript = " ".join(transcript)
+    transcript_file_saved_location = os.path.join(TRANSCRIPT_DATA_STORAGE,
+                                                  PLACEHOLDER_FILE_NAME + TRANSCRIPT_FILE_EXTENSION)
+    with open(transcript_file_saved_location, "w") as file:
+        file.writelines(transcript)
+        print("Transcript text saved.")
 
 
 def main():
     page_text = get_page_data_from_url(TEST_URL)
-    print(parse_page_data_from_text(page_text))
+    if page_text:
+        parse_audio_from_page_text(page_text)
+        parse_transcript_from_page_text(page_text)
 
 
 if __name__ == "__main__":

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,0 +1,60 @@
+'''
+References:
+- https://wamiller0783.github.io/TED-scraping-post.html
+- https://github.com/The-Gupta/TED-Scraper/blob/master/Scraper.ipynb
+'''
+
+from bs4 import BeautifulSoup, Comment
+import json
+import requests
+import os
+import re
+
+from time import sleep
+from random import randint
+
+import pandas as pd
+
+from dateutil import parser
+import sys
+
+
+TEST_URL = "https://www.ted.com/talks/abdallah_ewis_the_forgotten_queen_of_egypt"
+
+DATA_STORAGE_ROOT = os.path.join(os.getcwd(), "scraper", "data")
+AUDIO_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "audio")
+TRANSCRIPT_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "transcript")
+
+
+def get_page_data_from_url(url):
+    """
+    Scrapes data from a url, given the url. Uses the 'requests' module to fetch data.
+    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks)
+    :param url: The url to scrape data from.
+    :return: Returns the page data, as a string.
+    """
+    response = requests.get(url)
+
+    if not response.ok:
+        print(f"Error encountered while accessing url: <{url}>")
+        return
+
+    print(response.text)
+
+
+def parse_page_data_from_text(page_text):
+    """
+    Obtains the audio and transcript of a page, given its page text.
+    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks)
+    :param page_text:
+    :return:
+    """
+    pass
+
+
+def main():
+    get_page_data_from_url(TEST_URL)
+
+
+if __name__ == "__main__":
+    main()

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,29 +1,31 @@
-'''
+"""
 References:
 - https://wamiller0783.github.io/TED-scraping-post.html
 - https://github.com/The-Gupta/TED-Scraper/blob/master/Scraper.ipynb
-'''
+"""
 
-from bs4 import BeautifulSoup, Comment
-import json
+from bs4 import BeautifulSoup
 import requests
 import os
 import re
 
-from time import sleep
-from random import randint
-
-import pandas as pd
-
-from dateutil import parser
-import sys
-
 
 TEST_URL = "https://www.ted.com/talks/abdallah_ewis_the_forgotten_queen_of_egypt"
 
+# Storage locations
 DATA_STORAGE_ROOT = os.path.join(os.getcwd(), "scraper", "data")
 AUDIO_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "audio")
 TRANSCRIPT_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "transcript")
+
+# Scraper constants
+START_OF_TRANSCRIPT = "<!-- Transcript text -->"
+END_OF_TRANSCRIPT = "<!-- /Transcript text -->"
+# Allow "." to match newlines using re.DOTALL
+TRANSCRIPT_REGEX_PATTERN = re.compile(f"{START_OF_TRANSCRIPT}(.*?){END_OF_TRANSCRIPT}", re.DOTALL)
+
+TRANSCRIPT_TEXT_PARAGRAPH_TAG = "p"
+TRANSCRIPT_TEXT_PARAGRAPH_PATTERN = re.compile(f"<{TRANSCRIPT_TEXT_PARAGRAPH_TAG}>(.*?)"
+                                               f"</{TRANSCRIPT_TEXT_PARAGRAPH_TAG}>", re.DOTALL)
 
 
 def get_page_data_from_url(url):
@@ -33,27 +35,59 @@ def get_page_data_from_url(url):
     :param url: The url to scrape data from.
     :return: Returns the page data, as a string.
     """
-    response = requests.get(url)
+    # Locate the transcript tab of the page
+    url = url + "/transcript"
 
+    response = requests.get(url)
     if not response.ok:
         print(f"Error encountered while accessing url: <{url}>")
         return
 
-    print(response.text)
+    return response.text
 
 
 def parse_page_data_from_text(page_text):
     """
     Obtains the audio and transcript of a page, given its page text.
     Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks)
+
+    Workflow:
+    - Isolate and extract the transcript from the page text using the front and back comment delimiters
+    - Use BeautifulSoup to tidy up the transcript by removing unnecessary HTML tags
+
     :param page_text:
     :return:
     """
-    pass
+    raw_transcript = TRANSCRIPT_REGEX_PATTERN.search(page_text)
+    if not raw_transcript:
+        print("No transcript was found.")
+        return
+
+    page_soup = BeautifulSoup(raw_transcript.group(1), "html.parser")
+
+    # Extract transcript elements using the 'p' tag
+    transcript_paragraphs = page_soup.find_all(TRANSCRIPT_TEXT_PARAGRAPH_TAG)
+
+    # Basic data cleaning
+    transcript = []
+    for paragraph in transcript_paragraphs:
+        paragraph = str(paragraph)
+
+        # Remove the 'p' tags at the start and end
+        paragraph = paragraph.replace(f"<{TRANSCRIPT_TEXT_PARAGRAPH_TAG}>", "")
+        paragraph = paragraph.replace(f"</{TRANSCRIPT_TEXT_PARAGRAPH_TAG}>", "")
+
+        # Remove excess spaces
+        paragraph = re.sub("\\s+", " ", paragraph).strip()
+
+        transcript.append(paragraph)
+
+    return " ".join(transcript)
 
 
 def main():
-    get_page_data_from_url(TEST_URL)
+    page_text = get_page_data_from_url(TEST_URL)
+    print(parse_page_data_from_text(page_text))
 
 
 if __name__ == "__main__":

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -6,19 +6,21 @@ References:
 
 from bs4 import BeautifulSoup
 import json
+import logging
 import requests
 import os
 import re
 from urllib import request
 
+logger = logging.getLogger()
+logging.basicConfig(level="INFO", format="%(levelname)s: %(filename)s: %(message)s")
 
-TEST_URL = "https://www.ted.com/talks/ashley_whillans_3_rules_for_better_work_life_balance"
+TEST_URLS = [
+    "https://www.ted.com/talks/ashley_whillans_3_rules_for_better_work_life_balance"
+]
 
 # Storage locations
 DATA_STORAGE_ROOT = os.path.join(os.getcwd(), "scraper", "data")
-AUDIO_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "audio")
-TRANSCRIPT_DATA_STORAGE = os.path.join(DATA_STORAGE_ROOT, "transcript")
-PLACEHOLDER_FILE_NAME = "placeholder"
 
 
 def get_page_data_from_url(url):
@@ -33,7 +35,7 @@ def get_page_data_from_url(url):
 
     response = requests.get(url)
     if not response.ok:
-        print(f"No transcript exists: <{url}>")
+        logger.warning(f"No transcript exists: <{url}>")
         return None
 
     return response.text
@@ -46,28 +48,29 @@ END_OF_METADATA = '\)</script>'
 # Allow "." to match newlines using re.DOTALL
 METADATA_REGEX_PATTERN = re.compile(f"{START_OF_METADATA}(.*?){END_OF_METADATA}", re.DOTALL)
 METADATA_PATH_TO_AUDIO = ["__INITIAL_DATA__", "talks", 0, "downloads", "audioDownload"]
-AUDIO_FILE_EXTENSION = ".mp3"
+AUDIO_FILE_NAME = "audio.mp3"
 
 
-def parse_audio_from_page_text(page_text):
+def parse_audio_from_page_text(page_text, saved_folder_name):
     """
     Obtains the audio data of a page, given its page text.
-    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks)
+    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks).
 
     Workflow:
     - Isolate and extract the audio download link from the page text using tag delimiters
     - Call a download request to the audio download link to obtain the audio
 
     :param page_text: The raw page text from the website, as parsed by the requests module.
+    :param saved_folder_name: The folder name to save this file to.
     :return: No return value, but will save the audio file to the path in AUDIO_DATA_STORAGE.
     """
     if not page_text:
-        print("No page text was passed to audio parser.")
+        logger.error("No page text was passed to audio parser.")
         return
 
     raw_metadata = METADATA_REGEX_PATTERN.search(page_text)
     if not raw_metadata:
-        print("No metadata object was found.")
+        logger.warning("No metadata object was found.")
         return
 
     json_metadata = json.loads(raw_metadata.group(1))
@@ -82,16 +85,16 @@ def parse_audio_from_page_text(page_text):
             # This is because the metadata object combines both nested lists and nested dicts.
             audio_metadata_url = audio_metadata_url[key]
         except (KeyError, IndexError):
-            print("The specified path to the audio download does not exist.")
+            logger.warning("The specified path to the audio download does not exist.")
             return
 
     if not audio_metadata_url:
-        print("No audio download link exists.")
+        logger.warning("No audio download link exists.")
         return
 
-    audio_file_saved_location = os.path.join(AUDIO_DATA_STORAGE, PLACEHOLDER_FILE_NAME + AUDIO_FILE_EXTENSION)
+    audio_file_saved_location = os.path.join(DATA_STORAGE_ROOT, saved_folder_name, AUDIO_FILE_NAME)
     _, _ = request.urlretrieve(audio_metadata_url, filename=audio_file_saved_location)
-    print("Audio file saved.")
+    logger.info("Audio file saved.")
 
 
 # Transcript constants
@@ -100,28 +103,29 @@ END_OF_TRANSCRIPT = "<!-- /Transcript text -->"
 # Allow "." to match newlines using re.DOTALL
 TRANSCRIPT_REGEX_PATTERN = re.compile(f"{START_OF_TRANSCRIPT}(.*?){END_OF_TRANSCRIPT}", re.DOTALL)
 TRANSCRIPT_TEXT_PARAGRAPH_TAG = "p"
-TRANSCRIPT_FILE_EXTENSION = ".txt"
+TRANSCRIPT_FILE_NAME = "transcript.txt"
 
 
-def parse_transcript_from_page_text(page_text):
+def parse_transcript_from_page_text(page_text, saved_folder_name):
     """
     Obtains the speech transcript of a page, given its page text.
-    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks)
+    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks).
 
     Workflow:
     - Isolate and extract the transcript from the page text using the front and back comment delimiters
     - Use BeautifulSoup to tidy up the transcript by removing unnecessary HTML tags
 
     :param page_text: The raw page text from the website, as parsed by the requests module.
+    :param saved_folder_name: The folder name to save this file to.
     :return: No return value, but will save the transcript to the path in TRANSCRIPT_DATA_STORAGE
     """
     if not page_text:
-        print("No page text was passed to transcript parser.")
+        logger.error("No page text was passed to transcript parser.")
         return
 
     raw_transcript = TRANSCRIPT_REGEX_PATTERN.search(page_text)
     if not raw_transcript:
-        print("No transcript was found.")
+        logger.warning("No transcript was found.")
         return
 
     page_soup = BeautifulSoup(raw_transcript.group(1), "html.parser")
@@ -144,18 +148,40 @@ def parse_transcript_from_page_text(page_text):
         transcript.append(paragraph)
 
     transcript = " ".join(transcript)
-    transcript_file_saved_location = os.path.join(TRANSCRIPT_DATA_STORAGE,
-                                                  PLACEHOLDER_FILE_NAME + TRANSCRIPT_FILE_EXTENSION)
+    transcript_file_saved_location = os.path.join(DATA_STORAGE_ROOT, saved_folder_name, TRANSCRIPT_FILE_NAME)
     with open(transcript_file_saved_location, "w") as file:
         file.writelines(transcript)
-        print("Transcript text saved.")
+        logger.info("Transcript text saved.")
+
+
+# General constants
+START_OF_TED_URL = "https://www.ted.com/talks/"
+
+
+def scrape_data_from_url(url):
+    """
+    Attempts to scrape the audio file and transcript text from the given webpage.
+    Specifically written to scrape data from the TEDTalks page (root: https://www.ted.com/talks).
+
+    If either the audio file or the transcript does not exist, then this method will not scrape anything.
+    Otherwise, the data will be saved to a folder marked by the url.
+    :param url: The url to scrape data from.
+    :return: No return value.
+    """
+    assert url.startswith(START_OF_TED_URL), f"URL given does not start with expected URL root: <{url}>"
+
+    page_text = get_page_data_from_url(url)
+    if page_text:
+        saved_folder_name = url.replace(START_OF_TED_URL, "")
+        os.mkdir(os.path.join(DATA_STORAGE_ROOT, saved_folder_name))
+        parse_audio_from_page_text(page_text, saved_folder_name)
+        parse_transcript_from_page_text(page_text, saved_folder_name)
 
 
 def main():
-    page_text = get_page_data_from_url(TEST_URL)
-    if page_text:
-        parse_audio_from_page_text(page_text)
-        parse_transcript_from_page_text(page_text)
+    for url in TEST_URLS:
+        logger.info(f"Scraping from url: <{url}>")
+        scrape_data_from_url(url)
 
 
 if __name__ == "__main__":

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -179,6 +179,9 @@ def scrape_data_from_url(url):
 
 
 def main():
+    if not os.path.isdir(DATA_STORAGE_ROOT):
+        os.mkdir(DATA_STORAGE_ROOT)
+
     for url in TEST_URLS:
         logger.info(f"Scraping from url: <{url}>")
         scrape_data_from_url(url)


### PR DESCRIPTION
Features:
- Allow scraping of multiple urls, provided a base url (see method `get_all_video_urls()`)
- Each url will be scraped only if both the audio download link and transcript are available
- Scraping process will obtain the audio of the talk, and the accompanying transcript
- Data will be saved to a 'data' folder inside the scraper, with the following format:
    - data
        - ted_talk_name_1
            - audio.mp3
            - transcript.txt
        - ted_talk_name_2
            - audio.mp3
            - transcript.txt

IMPORTANT:
- To scrape more data, ensure to remove lines 56-58 (marked as "proof of concept"). These lines are there to get a toy dataset.