### PR TITLE
feat: Add scraper for TED2SRT website.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ speech_command*
 SpeechCommands/
 train-clean*
 Libri*
-scraper/
+
+# Ignore only the folder used to store data
+scraper/data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -5,12 +5,16 @@ References:
 """
 
 from bs4 import BeautifulSoup
+from moviepy import editor
+import requests
+from urllib import request, error
+
+from ast import literal_eval
 import json
 import logging
-import requests
 import os
 import re
-from urllib import request
+import shutil
 
 # Logger setup
 logger = logging.getLogger()
@@ -24,6 +28,10 @@ TED_URL_HOMEPAGE = "https://www.ted.com"
 TED_URL_PREFIX = "https://www.ted.com/talks/"
 TED_POPULAR_PAGE_URL = "https://www.ted.com/talks?sort=popular&page="
 
+TED_SRT_HOMEPAGE = "https://ted2srt.org/"
+TED_SRT_TALKS = "talks/"
+TED_SRT_TALKPAGE = TED_SRT_HOMEPAGE + TED_SRT_TALKS
+
 
 def main():
     if not os.path.isdir(DATA_STORAGE_ROOT):
@@ -33,11 +41,168 @@ def main():
             logging.error("Unable to create data storage folder.")
             raise Exception("Ensure that the current working directory is set to the project root.")
 
-    video_urls = get_all_video_urls(TED_POPULAR_PAGE_URL)
+    # Uncomment to parse transcripts and audio from the TEDTalks website
+    # logging.info("Parsing audio files with transcripts from TEDTalks website...")
+    # video_urls = get_all_video_urls(TED_POPULAR_PAGE_URL)
+    # for url in video_urls:
+    #     scrape_data_from_url(url)
 
+    # Uncomment to parse SRT transcripts and audio from the TED2SRT website
+    logging.info("Parsing audio files with SRT transcripts from TED2SRT website...")
+    video_urls = get_all_srt_video_urls(TED_SRT_HOMEPAGE)
     for url in video_urls:
-        logger.info(f"Scraping from url: <{url}>")
-        scrape_data_from_url(url)
+        scrape_data_from_srt_url(url)
+
+
+## Code that handles scraping from the TED2SRT website
+
+
+# TED2SRT website constants
+SUB_URL_KEY = "slug"
+
+
+def get_all_srt_video_urls(base_url):
+    """
+    Gets all video urls, given the base url page. This is designed to work specifically for the TED2SRT page.
+    :param base_url: The base url page (e.g. front page, 'all videos' page) to start searching from.
+    :return: Returns a list of all video urls found.
+    """
+    response = requests.get(base_url)
+    page_soup = BeautifulSoup(response.text, "html.parser")
+
+    all_talks_object = page_soup.select("script")[0].string
+    all_talks_list = literal_eval(all_talks_object.split(" = ")[1])
+
+    all_sub_urls = [talk_dict[SUB_URL_KEY] for talk_dict in all_talks_list]
+
+    logging.info(f"Found {len(all_sub_urls)} URLs. Depending on website format, this may only be the first screen.")
+
+    urls = [TED_SRT_HOMEPAGE + TED_SRT_TALKS + sub_url for sub_url in all_sub_urls]
+    logging.debug(f"URLs found are: {urls}")
+    return urls
+
+
+# TED2SRT specific page constants
+VIDEO_DOWNLOAD_SUB_URL_KEY = "mediaSlug"
+START_OF_AUDIO_DOWNLOAD_URL = "https://download.ted.com/talks/"
+END_OF_AUDIO_DOWNLOAD_URL = "-320k.mp4"
+
+VIDEO_SRT_ID_SUB_URL_KEY = "id"
+START_OF_SRT_TRANSCRIPT_URL = "https://ted2srt.org/api/talks/"
+END_OF_SRT_TRANSCRIPT_URL = "/transcripts/download/srt?lang=en"
+
+
+def scrape_data_from_srt_url(url):
+    """
+    Attempts to scrape the audio file and SRT transcript from the given webpage.
+    Specifically written to scrape data from the TED2SRT page (root: https://ted2srt.org/).
+
+    If either the audio file or the SRT transcript does not exist, then this method will not scrape anything.
+    Otherwise, the data will be saved to a folder marked by the url.
+    :param url: The url to scrape data from.
+    :return: No return value.
+    """
+    logger.info(f"\n\nScraping from url: <{url}>")
+    response = requests.get(url)
+    page_soup = BeautifulSoup(response.text, "html.parser")
+
+    # Identify the metadata object and parse the key phrases needed for video and SRT download
+    talk_metadata_string = page_soup.select("script")[0].string
+    talk_metadata_object = literal_eval(talk_metadata_string.split(" = ")[1])
+
+    srt_download_keyword = str(talk_metadata_object[VIDEO_SRT_ID_SUB_URL_KEY])
+    video_download_keyword = str(talk_metadata_object[VIDEO_DOWNLOAD_SUB_URL_KEY])
+
+    srt_download_url = START_OF_SRT_TRANSCRIPT_URL + srt_download_keyword + END_OF_SRT_TRANSCRIPT_URL
+    video_download_url = START_OF_AUDIO_DOWNLOAD_URL + video_download_keyword + END_OF_AUDIO_DOWNLOAD_URL
+
+    saved_folder_name = url.replace(TED_SRT_TALKPAGE, "")
+    saved_folder_path = os.path.join(DATA_STORAGE_ROOT, saved_folder_name)
+
+    success_status = download_and_save_srt_transcript_text(srt_download_url, saved_folder_path)
+    if not success_status:
+        return
+
+    download_and_save_video_file(video_download_url, saved_folder_path)
+
+
+# Video constants
+VIDEO_FILE_EXTENSION = "video.mp4"
+AUDIO_FILE_EXTENSION = "audio.mp3"
+SRT_TRANSCRIPT_FILE_EXTENSION = "srt_transcript.txt"
+
+
+def download_and_save_video_file(video_download_url, path_to_save_to):
+    """
+    Downloads a video file, given its url link. Converts the video file to audio. Saves the file to the required folder.
+    Specifically designed for the TED2SRT website. Note that no audio download exists. Therefore, the video must be
+    downloaded first, and then converted into audio. To save space, the video file is then deleted.
+    :param video_download_url: The url to download the video from.
+    :param path_to_save_to: The folder name to save this file to.
+    :return: Returns True if the download was successful, and False otherwise.
+    """
+    if not os.path.isdir(path_to_save_to):
+        os.mkdir(path_to_save_to)
+
+    video_file_saved_location = os.path.join(path_to_save_to, VIDEO_FILE_EXTENSION)
+    try:
+        _, _ = request.urlretrieve(video_download_url, filename=video_file_saved_location)
+        logger.info("Video file saved.")
+    except error.HTTPError:
+        logger.warning("No video file of lowest quality found. Deleting this specific data folder...")
+        srt_transcript_file_saved_location = os.path.join(path_to_save_to, SRT_TRANSCRIPT_FILE_EXTENSION)
+
+        if os.path.isfile(srt_transcript_file_saved_location):
+            shutil.rmtree(path_to_save_to)
+
+        if os.path.isdir(path_to_save_to):
+            os.rmdir(path_to_save_to)
+
+        return False
+
+    logger.info("Converting video.mp4 file to audio.mp3 file...")
+    audio_file_saved_location = os.path.join(path_to_save_to, AUDIO_FILE_EXTENSION)
+
+    video = editor.VideoFileClip(video_file_saved_location)
+    audio = video.audio
+    audio.write_audiofile(audio_file_saved_location, verbose=False, logger=None)
+    video.close()
+
+    os.remove(video_file_saved_location)
+    logging.info("Audio file saved. Video file deleted.")
+    return True
+
+
+def download_and_save_srt_transcript_text(srt_transcript_url, path_to_save_to):
+    """
+    Saves the transcript text to the required folder as a file. This is specifically designed to work with the TED2SRT
+    website.
+    :param srt_transcript_url: The url to download the srt transcript from.
+    :param path_to_save_to: The folder name to save this file to.
+    :return: Returns True if the download was successful, and False otherwise.
+    """
+    if not os.path.isdir(path_to_save_to):
+        os.mkdir(path_to_save_to)
+
+    srt_transcript_file_saved_location = os.path.join(path_to_save_to, SRT_TRANSCRIPT_FILE_EXTENSION)
+    try:
+        _, _ = request.urlretrieve(srt_transcript_url, filename=srt_transcript_file_saved_location)
+        logger.info("SRT transcript saved.")
+        return True
+    except error.HTTPError:
+        logger.warning("No SRT transcript found. Deleting this specific data folder...")
+        audio_file_saved_location = os.path.join(path_to_save_to, VIDEO_FILE_EXTENSION)
+
+        if os.path.isfile(audio_file_saved_location):
+            shutil.rmtree(path_to_save_to)
+
+        if os.path.isdir(path_to_save_to):
+            os.rmdir(path_to_save_to)
+
+        return False
+
+
+## Code that handles scraping from the TEDTalks website
 
 
 def get_all_video_urls(base_url):
@@ -82,6 +247,8 @@ def scrape_data_from_url(url):
     :return: No return value.
     """
     assert url.startswith(TED_URL_PREFIX), f"Url provided does not start with expected url: <{url}>"
+    logger.info(f"\n\nScraping from url: <{url}>")
+
     saved_folder_name = url.replace(TED_URL_PREFIX, "")
     saved_folder_path = os.path.join(DATA_STORAGE_ROOT, saved_folder_name)
 


### PR DESCRIPTION
Features:
- Scrapes audio files and SRT transcripts from TED2SRT website.

**IMPORTANT**:
- No audio download link exists. As a workaround, the lowest-quality video is downloaded and subsequently converted into audio.
- Only the first page of videos (20 videos) will be attempted. This is because the layout of the page is not easily retrievable all at once. Regardless, the 12 valid videos out of 20 should be enough.
- Some SRT transcripts might be slightly out of sync, due to the opening TED jingle. The majority appear to be fine. This can be detected by checking the first timestamp of the SRT. It should start around 7 seconds in; otherwise you need to manually adjust.
